### PR TITLE
Updating the orchestrator elements of the XML configuration file

### DIFF
--- a/configuration_manager/configuration_settings.xml
+++ b/configuration_manager/configuration_settings.xml
@@ -15,12 +15,15 @@
             <get_version_option>--version</get_version_option>
           </cluster>
         </executors>
-        <simulation_models>
+        <models>
           <models_dir>${CO_SIM_INSTALL_DIR}/models/</models_dir>
-        </simulation_models>
-        <broker_translators>
-          <translators_dir>${CO_SIM_INSTALL_DIR}/translators/</translators_dir>
-        </broker_translators>
+        </models>
+        <transformers>
+          <transformers_dir>${CO_SIM_INSTALL_DIR}/transformers/</transformers_dir>
+        </transformers>
+        <visualizers>
+          <visualizers_dir>${CO_SIM_INSTALL_DIR}/transformers/<visualizers_dir>
+        </visualizers>
     </orchestrator>
     <log_configurations>
         <version>1</version>

--- a/configuration_manager/configuration_settings.xml
+++ b/configuration_manager/configuration_settings.xml
@@ -1,11 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <settings>
-    <launcher_configurations>
-        <foo>
-            <bar></bar>
-        </foo>
-        <test_type>cluster</test_type>
-    </launcher_configurations>
+    <orchestrator>
+        <executors>
+          <local>
+            <command>mpirun</command>
+            <n_tasks_option>-n</n_tasks_option>
+            <n_tasks_default_value>2</n_tasks_default_value>
+            <get_version_option>-V</get_version_option>
+          </local>
+          <cluster>
+            <command>srun</command>
+            <n_tasks_option>-n</n_tasks_option>
+            <n_tasks_default_value>2</n_tasks_default_value>
+            <get_version_option>--version</get_version_option>
+          </cluster>
+        </executors>
+        <simulation_models>
+          <models_dir>${CO_SIM_INSTALL_DIR}/models/</models_dir>
+        </simulation_models>
+        <broker_translators>
+          <translators_dir>${CO_SIM_INSTALL_DIR}/translators/</translators_dir>
+        </broker_translators>
+    </orchestrator>
     <log_configurations>
         <version>1</version>
         <disable_existing_loggers>False</disable_existing_loggers>


### PR DESCRIPTION
Adding the first version of the XML elements into the global XML config file used by the configuration manager.

### \<executors\> 
refers to the programs able to start jobs/processes on local or cluster systems.

### \<simulation_models\>
refers to the global configuration related to the environment where the simulation models will be run.

### \<broker_translators\>
refers to the global configuration related to the environment where the information brokers (translator) will be run.

**NOTE**: The <get_version_option> element has been added as a alternative to be used during the deploying stage in order to check if the executor program is available. (deploying stage precedes the execution/simulation stage)