### PR TITLE
MVP without steering

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 [submodule "launcher/EBRAINS-RichEndpoint"]
 	path = launcher/EBRAINS-RichEndpoint
 	url = https://github.com/multiscale-cosim/EBRAINS-RichEndpoint
+[submodule "launcher/routines/EBRAINS-InterscaleHUB"]
+	path = launcher/routines/EBRAINS-InterscaleHUB
+	url = git@github.com:multiscale-cosim/EBRAINS-InterscaleHUB.git

--- a/launcher/README.md
+++ b/launcher/README.md
@@ -1,18 +1,17 @@
 Prerequisite:
 
-`export PYTHONPATH=/path/to/TVB-NEST/configuration_manager`
+`export PYTHONPATH=/path/to//TVB-NEST/<submodules>:`
 
 e.g.
 
-`export PYTHONPATH=/home/user/TVB-NEST/configuration_manager/`
+`export PYTHONPATH=~/TVB-NEST/launcher/EBRAINS-RichEndpoint:~/TVB-NEST/configuration_manager:~/TVB-NEST/launcher/routines/EBRAINS-InterscaleHUB/python`
 
 Launching a Co-Simulation plan:
 
 `python3 /path/to/launcher/main.py --global-settings /path/to/co_simulation_global_Settings.xml --action-plan /path/to/plans/action_plan.xml --parameters /path/to/parameters/co_simulation_parameters.xml`
 
 e.g.
-
-`python3 ~/TVB-NEST/launcher/main.py --global-settings ~/TVB-NEST/configuration_manager/global_settings.xml --action-plan ~/TVB-NEST/launcher/plans/translator_nest_to_tvb_on_local.xml --parameters ~/TVB-NEST/launcher/parameters/nest_to_tvb_parameters.xml`
+`python3 ~/TVB-NEST/launcher/main.py --global-settings ~/TVB-NEST/configuration_manager/global_settings.xml --action-plan ~/TVB-NEST/launcher/plans/nest_to_tvb_transformer_on_local.xml --parameters ~/TVB-NEST/launcher/parameters/nest_to_tvb_parameters.xml`
 
 
 

--- a/launcher/actions/test_input_nest_to_tvb.xml
+++ b/launcher/actions/test_input_nest_to_tvb.xml
@@ -30,10 +30,12 @@
                 </performer_arguments>
             </performer>
             <routine>
-                <routine_code>{CO_SIM_ROUTINES_DIR}/nest_elephant_tvb/translation/test_file/test_input_nest_to_tvb.py</routine_code>
+                <!-- <routine_code>{CO_SIM_ROUTINES_DIR}/nest_elephant_tvb/translation/test_file/test_input_nest_to_tvb.py</routine_code> -->
+                <routine_code>{CO_SIM_ROUTINES_DIR}/EBRAINS-InterscaleHUB/python/tests/app_sim1.py</routine_code>
                 <routine_arguments>
-                    <argv_1_comm_file>{CO_SIM_RESULTS_DIR}{CO_SIM_INPUT_FILE}</argv_1_comm_file>
-                    <argv_2_delay>{CO_SIM_DELAY}</argv_2_delay>
+                    <!-- <argv_1_comm_file>{CO_SIM_RESULTS_DIR}{CO_SIM_INPUT_FILE}</argv_1_comm_file>
+                    <argv_2_delay>{CO_SIM_DELAY}</argv_2_delay> -->
+                    <argv_1_value>2</argv_1_value>
                 </routine_arguments>
             </routine>
         </action>

--- a/launcher/actions/test_receive_nest_to_tvb.xml
+++ b/launcher/actions/test_receive_nest_to_tvb.xml
@@ -30,9 +30,11 @@
                 </performer_arguments>
             </performer>
             <routine>
-                <routine_code>{CO_SIM_ROUTINES_DIR}/nest_elephant_tvb/translation/test_file/test_receive_nest_to_tvb.py</routine_code>
+                <!-- <routine_code>{CO_SIM_ROUTINES_DIR}/nest_elephant_tvb/translation/test_file/test_receive_nest_to_tvb.py</routine_code> -->
+                <routine_code>{CO_SIM_ROUTINES_DIR}//EBRAINS-InterscaleHUB/python/tests/app_sim2.py</routine_code>
                 <routine_arguments>
-                    <argv_1_comm_file>{CO_SIM_RESULTS_DIR}{CO_SIM_OUTPUT_FILE}</argv_1_comm_file>
+                    <!-- <argv_1_comm_file>{CO_SIM_RESULTS_DIR}{CO_SIM_OUTPUT_FILE}</argv_1_comm_file> -->
+                    <argv_1_value>2</argv_1_value>
                 </routine_arguments>
             </routine>
         </action>

--- a/launcher/actions/transformer_nest_to_tvb.xml
+++ b/launcher/actions/transformer_nest_to_tvb.xml
@@ -30,11 +30,13 @@
                 </performer_arguments>
             </performer>
             <routine>
-                <routine_code>{CO_SIM_ROUTINES_DIR}/nest_elephant_tvb/translation/nest_to_tvb.py</routine_code>
+                <!-- <routine_code>{CO_SIM_ROUTINES_DIR}/nest_elephant_tvb/translation/nest_to_tvb.py</routine_code> -->
+                <routine_code>{CO_SIM_ROUTINES_DIR}/EBRAINS-InterscaleHUB/python/tests/app_interscalehub.py</routine_code>
                 <routine_arguments>
-                    <argv_1_results_dir>{CO_SIM_RESULTS_DIR}</argv_1_results_dir>
+                    <!-- <argv_1_results_dir>{CO_SIM_RESULTS_DIR}</argv_1_results_dir>
                     <argv_2_input_file>{CO_SIM_INPUT_FILE}</argv_2_input_file>
-                    <argv_3_output_file>{CO_SIM_OUTPUT_FILE}</argv_3_output_file>
+                    <argv_3_output_file>{CO_SIM_OUTPUT_FILE}</argv_3_output_file> -->
+                    <argv_1_value>2</argv_1_value>
                 </routine_arguments>
             </routine>
         </action>


### PR DESCRIPTION
MVP without steering support on InterScaleHub.

### Testing

Passes both tests i.e. TVB_to_NEST and NEST_to_TVB.

It should run after cloning the repo, and setting up the environment variables as described in [Read Me](https://github.com/mfahdaz/TVB-NEST/blob/master/launcher/README.md).

### Next Steps

Interfaces for InterScaleHub to communicate with Application Companions (such as for steering and minimum step sizes synchronization purposes).
